### PR TITLE
fix bugs about flush log in easy_logger and read_singal in libevent_handler

### DIFF
--- a/easy_logger/async_log.txt
+++ b/easy_logger/async_log.txt
@@ -1,0 +1,1 @@
+[2019-12-12 09:40:44.692] [/home/weixiaoxian/percona/multi-master-tool/easy_logger/test_main.cc : 27] [warning] test log message

--- a/easy_logger/include/easylogger.h
+++ b/easy_logger/include/easylogger.h
@@ -6,7 +6,7 @@
 #include<string>
 #include<sstream>
 
-#include "spdlog/async.h" 
+#include "spdlog/async.h"
 #include "spdlog/sinks/basic_file_sink.h"
 #include "spdlog/spdlog.h"
 
@@ -25,6 +25,7 @@ class EasyLogger
     virtual ~EasyLogger()
     {
         auto s = m_oss.str();
+        if(s.length() <= 0) return;
         switch (m_level)
         {
         case LOG_LEVEL::info:
@@ -41,41 +42,51 @@ class EasyLogger
         default:
             break;
         }
+        if(free_flush)
+        {
+            async_log->flush();
+        }
     };
-    
+
+    EasyLogger & force_flush()
+    {
+        free_flush = true;
+        return *this;
+    }
+
     template <typename T>
     EasyLogger &operator<<(const T &rhs) {
         m_oss << rhs;
         return (*this);
     }
 
-    explicit EasyLogger(std::string log_name,std::string log_path,LOG_LEVEL level)
-    {
-        async_log = spdlog::get(log_name);
-        if(async_log == NULL) 
-            async_log = spdlog::basic_logger_mt<spdlog::async_factory>(log_name, log_path);
-        m_level = level;
-    }
-    
-    
-    explicit EasyLogger(std::string file_name,int line_num,std::string log_path,LOG_LEVEL level)
+    // explicit EasyLogger(std::string log_name,std::string log_path,LOG_LEVEL level)
+    // {
+    //     async_log = spdlog::get(log_name);
+    //     if(async_log == NULL)
+    //         async_log = spdlog::basic_logger_mt<spdlog::async_factory>(log_name, log_path);
+    //     m_level = level;
+    // }
+
+    explicit EasyLogger(std::string file_name,int line_num,std::string log_path,LOG_LEVEL level, bool flush_control = false)
     {
         source_location = "";
         source_location += file_name;
         source_location += " : ";
         source_location += std::to_string(line_num);
         async_log = spdlog::get(source_location);
-        if(async_log == NULL) 
+        if(async_log == NULL)
             async_log = spdlog::basic_logger_mt<spdlog::async_factory>(source_location, log_path);
         m_level = level;
+        free_flush = flush_control;
     }
-    
 
     private:
     LOG_LEVEL m_level;
     std::ostringstream m_oss;
     std::shared_ptr<spdlog::logger> async_log;
     std::string source_location;
+    bool free_flush;
 };
 
 #define EasyLoggerWithTrace(p,l)             \

--- a/easy_logger/test_main.cc
+++ b/easy_logger/test_main.cc
@@ -1,30 +1,31 @@
 #include "include/easylogger.h"
 #include <iostream>
 
-void fun1()
-{
-     EasyLogger("fun","./async_log.txt",EasyLogger::warn) << "fun1 : test log message";
-    EasyLoggerWithTrace("./async_log.txt",EasyLogger::warn) << "FUN1 : test log message";
-}
+// void fun1()
+// {
+//      EasyLogger("fun","./async_log.txt",EasyLogger::warn) << "fun1 : test log message";
+//     EasyLoggerWithTrace("./async_log.txt",EasyLogger::warn) << "FUN1 : test log message";
+// }
 
-void fun2()
-{
-     EasyLogger("fun","./async_log.txt",EasyLogger::warn) << "fun2 : test log message";
-    EasyLoggerWithTrace("./async_log.txt",EasyLogger::warn) << "FUN2 : test log message";
+// void fun2()
+// {
+//      EasyLogger("fun","./async_log.txt",EasyLogger::warn) << "fun2 : test log message";
+//     EasyLoggerWithTrace("./async_log.txt",EasyLogger::warn) << "FUN2 : test log message";
 
-}
+// }
 
 
 
 int main(void)
 {
-    fun1();
-    fun2();
+    //fun1();
+    //fun2();
     // EasyLogger("test_log","./async_log.txt",EasyLogger::error) << "test log message";
     //   EasyLogger("test_log","./async_log.txt",EasyLogger::info) << "test log message";
     //    EasyLogger("test_log","./async_log.txt",EasyLogger::debug) << "test log message";
-    EasyLogger("test_log","./async_log.txt",EasyLogger::warn) << "test log message";
-    EasyLoggerWithTrace("./async_log.txt",EasyLogger::warn) << "test log message";
-    EasyLoggerWithTrace("./async_log.txt",EasyLogger::error) << "test log message";
+    //EasyLogger("test_log","./async_log.txt",EasyLogger::warn) << "test log message";
+    EasyLoggerWithTrace("./async_log.txt",EasyLogger::warn).force_flush() << "test log message";
+    //tmp_loggger.force_flush();
+    //EasyLoggerWithTrace("./async_log.txt",EasyLogger::error) << "test log message";
     return 0;
 }

--- a/multi_net_io/include/libevent_handle.h
+++ b/multi_net_io/include/libevent_handle.h
@@ -110,7 +110,7 @@ class LibeventHandle:public NetworkHandle
 
     ~LibeventHandle()
     {
-        if(isFree = false)
+        if(isFree == false)
             free_handle();
     }
 

--- a/multi_net_io/test/server_test.cc
+++ b/multi_net_io/test/server_test.cc
@@ -43,7 +43,7 @@ int main(int argc,char * argv[])
     while(1)
     {
         memset(temp_buf,0,sizeof(char)*50);
-        sleep(10);
+        sleep(4);
         cout << "listen count " << lib.get_listen_connection_count() << std::endl;
         lib.get_listen_connection_array(listen_array);
         int readsize = lib.wait_recive(listen_array[0],temp_buf);


### PR DESCRIPTION
+ easy_logger中添加了强制刷新策略
+ libevent中有return语句分支未解锁，导致了死锁，事件循环阻塞